### PR TITLE
fix(client): align x icon mobile navbar

### DIFF
--- a/client/src/components/general/navbar-mobile.tsx
+++ b/client/src/components/general/navbar-mobile.tsx
@@ -44,7 +44,7 @@ export function MobileNavbar({ className, links }: MobileNavbarProps) {
       {
         isMenuOpen &&
         <div className={cn("fixed flex flex-col items-center top-0 left-0 w-screen h-screen bg-background overflow-y-auto gap-6 p-6", className)}>
-          <button className="self-end" onClick={() => setIsMenuOpen(false)}><X /></button>
+          <button className="self-end mr-7" onClick={() => setIsMenuOpen(false)}><X /></button>
           <Link href="/" className="flex items-center gap-2" onClick={() => setIsMenuOpen(false)}>
             <Image src={LogoPng} alt="MakeUC Logo" width="128" height="128" />
           </Link>


### PR DESCRIPTION
Hi @john-whiting 

I moved the X icon a little over since it does not align with the hamburger icon in the nav mobile menu. I was at this for a good 3 hours until I figured I'll just edit straight on Github.

Have a good evening John.