### PR TITLE
Changes to discord bot scheduler.

### DIFF
--- a/discord-bot/src/commands/schedule.ts
+++ b/discord-bot/src/commands/schedule.ts
@@ -32,23 +32,33 @@ export const scheduleCommand = {
     ).addIntegerOption(option =>
       option.setName("day")
         .setDescription("Day to send message on")
-        .addChoices(
-          { name: "4", value: 4 },
-          { name: "5", value: 5 },
-        )
+        .setMinValue(1)
+        .setMaxValue(31)
         .setRequired(false)
     ).addIntegerOption(option =>
       option.setName("month")
         .setDescription("Month to send message on")
         .addChoices(
+          { name: "January", value: 1 },
+          { name: "February", value: 2 },
+          { name: "March", value: 3 },
+          { name: "April", value: 4 },
+          { name: "May", value: 5 },
+          { name: "June", value: 6 },
+          { name: "July", value: 7 },
+          { name: "August", value: 8 },
+          { name: "September", value: 9 },
+          { name: "October", value: 10 },
           { name: "November", value: 11 },
+          { name: "December", value: 12 }
         )
         .setRequired(false)
     ).addIntegerOption(option =>
       option.setName("year")
         .setDescription("Year to send message on")
         .addChoices(
-          { name: "2023", value: 2023 },
+          { name: "2024", value: 2024 },
+          { name: "2025", value: 2025 }
         )
         .setRequired(false)
     ),
@@ -79,6 +89,9 @@ export const scheduleCommand = {
     const month = (interaction.options.getInteger("month") ?? (dayjs().month() + 1)) - 1;
     const year = interaction.options.getInteger("year") ?? dayjs().year();
 
+    // This is something to be careful about. Docker containers are by default set to UTC. 
+    // in order to change the timezone of a container, first enter the container
+    // then run  `dpkg-reconfigure tzdata` as root and select desired timezone.
     const date = dayjs({
       year: year,
       month: month,

--- a/discord-bot/src/utils/scheduler.ts
+++ b/discord-bot/src/utils/scheduler.ts
@@ -98,7 +98,10 @@ export class Scheduler {
   }
 
   async scheduleEvent(event: Omit<ScheduledEvent, "timeout">): Promise<string> {
-    const offset = event.unixExecutionTime - dayjs().valueOf();
+    const currentTime = dayjs().valueOf();
+    const eventTime = dayjs(event.unixExecutionTime).valueOf();
+
+    const offset = eventTime - currentTime;
     if (offset > 2147483647) { throw new TooFarAwayScheduledEvent(); }
     if (offset <= 0) { throw new ImpossibleScheduledEvent(); }
 


### PR DESCRIPTION
These are some minor changes to the scheduler. In order for it to work, make sure the time zone for the docker container is not the default UTC.