### PR TITLE
Fix(discord): Create dayjs object with string instead of using an object

### DIFF
--- a/discord-bot/src/commands/schedule.ts
+++ b/discord-bot/src/commands/schedule.ts
@@ -1,6 +1,5 @@
 
 import dayjs from "dayjs";
-import objectSupport from "dayjs/plugin/objectSupport";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
@@ -14,7 +13,6 @@ import type { ChatInputCommandInteraction } from "discord.js";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
-dayjs.extend(objectSupport);
 
 export const scheduleCommand = {
   data: new SlashCommandBuilder()
@@ -86,18 +84,14 @@ export const scheduleCommand = {
     if (parsedTime.length !== 2) { return interaction.editReply({ content: "Invalid time format, please use HH:mm" }); }
     const [hours, minutes] = parsedTime as [number, number];
 
-    const day = interaction.options.getInteger("day") ?? dayjs().date();
-    const month = (interaction.options.getInteger("month") ?? (dayjs().month() + 1)) - 1;
     const year = interaction.options.getInteger("year") ?? dayjs().year();
+    const day = interaction.options.getInteger("day") ?? dayjs().date();
+    const month = interaction.options.getInteger("month") ?? dayjs().month() + 1; // Plus 1 since Dayjs month is 0-index-based, but we want 1-index-based to contruct the date string below
 
-    // Create all dates in the America/New_York timezone
-    const date = dayjs.tz({
-      year: year,
-      month: month,
-      day: day,
-      hour: hours,
-      minute: minutes,
-    }, "America/New_York");
+    const datetime_string = `${year}-${month}-${day} ${hours}:${minutes}:00`;
+
+    // Create the date in the America/New_York timezone
+    const date = dayjs.tz(datetime_string, "America/New_York");
 
     // Setup scheduled event
     const channelId = channel.id;


### PR DESCRIPTION
## What/Why
A previous PR #72 was merged in an attempt to "anchor" Discord scheduled messages created via the `/schedule` command to the "America/New_York" timezone.

However, that fix didn't work due to wrong usuage of the `dayjs.tz` method. In that PR, I attempted to use `dayjs.tz` with the `objectSupport` feature like:
```js
dayjs.tz({hour, minute, year, day, month}, "America/New_York")
```

However, upon further [inspection](https://github.com/iamkun/dayjs/blob/1f67767944c3ac7384c3128ddd805611e9ce8f57/src/plugin/timezone/index.js#L139), I found if the first argument to `dayjs.tz` is not a string, Dayjs actually creates the date in UTC, and would only use the timezone info for localization, instead of creating the original time in America/New_York.

Therefore, this PR fixes that by just using a datetime string (example: `2024-11-03 16:45:00`) instead of an object

## Dev Testing

I confirm this PR worked by temporarily changing the Railway deployment's Github branch to `discord-dayjs-fix`, allowing me to test the new version of the command on the Discord server

The Railway's branch has now been changed back to `main`, so when this PR is merged, the command shall work correctly.