### PR TITLE
fix(bot): case-insensitive verification

### DIFF
--- a/discord-bot/src/commands/verify.ts
+++ b/discord-bot/src/commands/verify.ts
@@ -34,7 +34,10 @@ export const verifyCommand = {
 
     const participant = await prisma.registrant.findFirst({
       where: {
-        email: email,
+        email: {
+          equals: email,
+          mode: "insensitive",
+        },
         registrationYear: 2024,
       },
     });


### PR DESCRIPTION
PostgreSQL uses case-sensitive search by default. Use `mode: "insensitive"` to use case-insensitive search.